### PR TITLE
Fixed and unified Sitespeed.io quiz syntax #141

### DIFF
--- a/quizzes/sitespeedio-webperf.md
+++ b/quizzes/sitespeedio-webperf.md
@@ -4,13 +4,15 @@
 
 Sitespeed.io...
 
-|                                                                 | `true` | `false` |
-| --------------------------------------------------------------- | ------ | ------- |
-| makes my website faster if I install it                         |  [ ]   |  [x]    |
-| analyses and checks websites against performance best practices |  [x]   |  [ ]    |
-| sends me weekly reports on my website's performance             |  [ ]   |  [x]    |
-| can be integrated with some continuous-integration tools        |  [x]   |  [ ]    |
-| can only be used from the command-line                          |  [x]   |  [ ]    |
+|                                                                   | `true` | `false` |
+| ----------------------------------------------------------------- | ------ | ------- |
+| `makes my website faster if I install it`                         |  [ ]   |  [x]    |
+| `analyses and checks websites against performance best practices` |  [x]   |  [ ]    |
+| `sends me weekly reports on my website's performance`             |  [ ]   |  [x]    |
+| `can be integrated with some continuous-integration tools`        |  [x]   |  [ ]    |
+| `can only be used from the command-line`                          |  [x]   |  [ ]    |
+
+> ` `
 
 ---
 
@@ -20,9 +22,11 @@ Sitespeed.io rules...
 
 |                                                                 | `true` | `false` |
 | --------------------------------------------------------------- | ------ | ------- |
-| are based on YSlow                                              |  [x]   |  [ ]    |
-| are strict and hurt my feelings                                 |  [x]   |  [ ]    |
-| cannot be created by third-party developers                     |  [ ]   |  [x]    |
+| `are based on YSlow`                                            |  [x]   |  [ ]    |
+| `are strict and hurt my feelings`                               |  [x]   |  [ ]    |
+| `cannot be created by third-party developers`                   |  [ ]   |  [x]    |
+
+> ` `
 
 ---
 
@@ -32,9 +36,11 @@ Sitespeed.io v3.x
 
 |                                                                 | `true` | `false` |
 | --------------------------------------------------------------- | ------ | ------- |
-| API is fully backwards-compatible with v2.x                     |  [ ]   |  [x]    |
-| does not depend on Java                                         |  [ ]   |  [x]    |
-| is the first NodeJS based version                               |  [x]   |  [ ]    |
-| works in Windows environments                                   |  [ ]   |  [x]    |
+| `API is fully backwards-compatible with v2.x`                   |  [ ]   |  [x]    |
+| `does not depend on Java`                                       |  [ ]   |  [x]    |
+| `is the first NodeJS based version`                             |  [x]   |  [ ]    |
+| `works in Windows environments`                                 |  [ ]   |  [x]    |
+
+> ` `
 
 ---


### PR DESCRIPTION
Well this was an interesting one...
- Empty strings added under the quiz options table in order for gitbook to format the quiz correctly.
- Monospace font used in questions.
